### PR TITLE
fix: [Stay In Touch] The Name Phone No Email Message text and frame are dark.

### DIFF
--- a/src/app/components/StayInTouch.tsx
+++ b/src/app/components/StayInTouch.tsx
@@ -10,22 +10,31 @@ import {
 import { useState } from "react";
 
 const CssTextField = styled(TextField)({
+  "& label": {
+    color: "black",
+  },
   "& label.Mui-focused": {
-    color: "#A0AAB4",
+    color: "black",
   },
   "& .MuiInput-underline:after": {
     borderBottomColor: "#B2BAC2",
   },
+
   "& .MuiOutlinedInput-root": {
     "& fieldset": {
-      borderColor: "#E0E3E7",
+      borderColor: "#2d2b2b",
+      borderWidth: "1.25px",
       borderRadius: 0,
     },
     "&:hover fieldset": {
       borderColor: "#B2BAC2",
+      borderWidth: "1.25px",
+      borderRadius: 0,
     },
     "&.Mui-focused fieldset": {
       borderColor: "#6F7E8C",
+      borderWidth: "1.25px",
+      borderRadius: 0,
     },
   },
 });


### PR DESCRIPTION
- change color and text TextField
Before
![image](https://github.com/user-attachments/assets/cb172a83-6865-4f36-8cf0-040d8d6b5fbd)
After
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/6ee2a1e5-04ce-4506-bc42-285706dcfced">