### PR TITLE
Fix: [Web page footer] The Banana Island topics are on separate lines.

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -36,15 +36,25 @@ export default function Footer() {
           justifyContent: "center",
         }}
       >
-        <Grid container spacing={2} sx={{ pt: "8rem" }}>
+        <Grid container spacing={2} sx={{ pt: "7rem" }}>
           <Grid>
             <Stack width={"400px"}>
               <Typography
-                sx={{ color: "white", fontSize: 30, fontFamily: "Manrope" }}
+                sx={{ color: "white", fontSize: 35, fontFamily: "Manrope" }}
               >
-                Banana Island
+                Banana
+                <br />
+                Island
               </Typography>
-              <Typography sx={{ color: "white", fontFamily: "Manrope" }}>
+              <Typography
+                sx={{
+                  color: "white",
+                  fontFamily: "Manrope",
+                  fontWeight: 200,
+                  width: "16rem",
+                  mt: "0.5rem",
+                }}
+              >
                 a community that gives you a taste of happiness, a place you’ll
                 love to live and an opportunity to build a home.
               </Typography>
@@ -114,7 +124,9 @@ export default function Footer() {
                   fontFamily: "Manrope",
                 }}
               >
-                Pineapple Island
+                Pineapple
+                <br />
+                Island
               </Typography>
               <Typography
                 sx={{

--- a/src/app/components/StayInTouch.tsx
+++ b/src/app/components/StayInTouch.tsx
@@ -10,22 +10,31 @@ import {
 import { useState } from "react";
 
 const CssTextField = styled(TextField)({
+  "& label": {
+    color: "black",
+  },
   "& label.Mui-focused": {
-    color: "#A0AAB4",
+    color: "black",
   },
   "& .MuiInput-underline:after": {
     borderBottomColor: "#B2BAC2",
   },
+
   "& .MuiOutlinedInput-root": {
     "& fieldset": {
-      borderColor: "#E0E3E7",
+      borderColor: "#2d2b2b",
+      borderWidth: "1.25px",
       borderRadius: 0,
     },
     "&:hover fieldset": {
       borderColor: "#B2BAC2",
+      borderWidth: "1.25px",
+      borderRadius: 0,
     },
     "&.Mui-focused fieldset": {
       borderColor: "#6F7E8C",
+      borderWidth: "1.25px",
+      borderRadius: 0,
     },
   },
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import Feature from "./components/Feature";
 import NavBar from "./components/NavBar";
 
 const manrope = Manrope({
-  weight: ["400", "700"],
+  weight: ["200", "300", "400","500","600", "700", "800"],
   style: ["normal"],
   subsets: ["latin"],
 });


### PR DESCRIPTION
- change font size, add <br/> to seperate line of "Banana Island"
- change font weight, width of description

**Ref**
<img width="282" alt="image" src="https://github.com/user-attachments/assets/f68505e1-31c8-4845-b254-ac0e61e6d0a1">

**After fix**
<img width="361" alt="image" src="https://github.com/user-attachments/assets/a29a0c58-43d7-47d1-8f7b-58107faf91f6">